### PR TITLE
Osborn/lando vs fixes

### DIFF
--- a/lando.vs-code.0.1/README.md
+++ b/lando.vs-code.0.1/README.md
@@ -1,51 +1,26 @@
-# Lando README
-
-This is the README for your extension "Lando". After writing up a brief description, we recommend including the following sections.
+# Lando Lanuage Syntax Extension
 
 ## Features
 
-Describe specific features of your extension including screenshots of your extension in action. Image paths are relative to this README file.
+Adds syntax highlighting for Lando.
 
-For example if there is an image subfolder under your extension project workspace:
+## Building / Installing
 
-\!\[feature X\]\(images/feature-x.png\)
+First create a vsce (Visual Studio Code Extension) package.
 
-> Tip: Many popular extensions utilize animations. This is an excellent way to show off your extension! We recommend short, focused animations that are easy to follow.
+```
+vsce package
+```
 
-## Requirements
-
-If you have any requirements or dependencies, add a section describing those and how to install and configure them.
-
-## Extension Settings
-
-Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
-
-For example:
-
-This extension contributes the following settings:
-
-* `myExtension.enable`: enable/disable this extension
-* `myExtension.thing`: set to `blah` to do something
+Now from the Visual Studio extensions page click the `...` menu and choose `Install from VSIX`
 
 ## Known Issues
 
-Calling out known issues can help limit users opening duplicate issues against your extension.
-
 ## Release Notes
-
-Users appreciate release notes as you update your extension.
 
 ### 1.0.0
 
-Initial release of ...
-
-### 1.0.1
-
-Fixed issue #.
-
-### 1.1.0
-
-Added features X, Y, and Z.
+Initial release
 
 -----------------------------------------------------------------------------------------------------------
 

--- a/lando.vs-code.0.1/package.json
+++ b/lando.vs-code.0.1/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "Lando syntax highlighting",
+    "name": "laando-syntax-highlighting",
     "displayName": "Lando",
     "description": "Lando language support",
     "version": "0.0.1",

--- a/lando.vs-code.0.1/package.json
+++ b/lando.vs-code.0.1/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "laando-syntax-highlighting",
+    "name": "lando-syntax-highlighting",
     "displayName": "Lando",
     "description": "Lando language support",
     "version": "0.0.1",

--- a/lando.vs-code.0.1/syntaxes/lando.tmLanguage.json
+++ b/lando.vs-code.0.1/syntaxes/lando.tmLanguage.json
@@ -16,7 +16,7 @@
 		"keywords": {
 			"patterns": [{
 				"name": "keyword.control.lando",
-				"match": "\\b(system|subsystem|inherit|client|contains|indexing|component|events|requirements|scenarios)\\b"
+				"match": "\\b(relation|system|subsystem|inherit|client|contains|indexing|component|events|requirements|scenarios)\\b"
 			}]
 		},
 		"strings": {


### PR DESCRIPTION
A couple of minor tweaks are required to build this extension into a `vsix` file that can be loaded into VS Code.

* use lower-case-name for the extension as required by the packager.
* Edit readme (also required by packager).  Added some packaging instructions.
* Added **relation** to keywords.